### PR TITLE
Fix/coupon display name

### DIFF
--- a/apps/admin/src/features/coupons/api/coupons-mapper.ts
+++ b/apps/admin/src/features/coupons/api/coupons-mapper.ts
@@ -1,3 +1,4 @@
+import { formatCouponName } from "@yeongseon/shared/utils/format-coupon-name";
 import type {
   AdminCoupon,
   AdminCouponFormValues,
@@ -8,6 +9,7 @@ import type {
 
 interface CouponMutationDto {
   name: string;
+  display_name: string;
   discount_type: CouponDiscountType;
   discount_value: number;
   max_discount_amount: number | null;
@@ -57,6 +59,7 @@ export function toAdminCoupon(value: unknown): AdminCoupon {
   return {
     id: stringValue(row.id),
     name: stringValue(row.name),
+    displayName: stringValue(row.display_name),
     discountType: discountTypeValue(row.discount_type),
     discountValue: numberValue(row.discount_value),
     maxDiscountAmount: nullableNumberValue(row.max_discount_amount),
@@ -77,6 +80,7 @@ export function toCouponMutationDto(
 
   return {
     name: values.name.trim(),
+    display_name: values.displayName.trim(),
     discount_type: values.discountType,
     discount_value: values.discountValue ?? 0,
     max_discount_amount: maxDiscountAmount,
@@ -90,6 +94,7 @@ export function toCouponMutationDto(
 export function toCouponFormValues(coupon: AdminCoupon): AdminCouponFormValues {
   return {
     name: coupon.name,
+    displayName: formatCouponName(coupon),
     discountType: coupon.discountType,
     discountValue: coupon.discountValue,
     maxDiscountAmount: coupon.maxDiscountAmount,

--- a/apps/admin/src/features/coupons/components/coupon-form.tsx
+++ b/apps/admin/src/features/coupons/components/coupon-form.tsx
@@ -38,6 +38,7 @@ interface ControlledTextFieldProps {
   label: string;
   type?: HTMLInputTypeAttribute;
   required?: boolean;
+  validate?: (value: unknown) => true | string;
   error?: string;
   textarea?: boolean;
   min?: number;
@@ -73,19 +74,20 @@ function ControlledTextField({
   label,
   type = "text",
   required,
+  validate,
   error,
   textarea,
   min,
   className,
 }: ControlledTextFieldProps): ReactNode {
-  const validate =
-    type === "number" ? createNumberValidator(label, min) : undefined;
+  const fieldValidator =
+    type === "number" ? createNumberValidator(label, min) : validate;
   const { field } = useController({
     control,
     name,
     rules: {
       required: required ? `${label}을 입력해주세요.` : false,
-      validate,
+      validate: fieldValidator,
     },
   });
   const value = field.value == null ? "" : String(field.value);
@@ -171,6 +173,11 @@ export function CouponForm({
         name="displayName"
         label="고객 표시명"
         required
+        validate={(value) =>
+          typeof value === "string" && value.trim().length > 0
+            ? true
+            : "표시명은 비워둘 수 없습니다"
+        }
         error={errors.displayName?.message}
       />
 

--- a/apps/admin/src/features/coupons/components/coupon-form.tsx
+++ b/apps/admin/src/features/coupons/components/coupon-form.tsx
@@ -160,9 +160,18 @@ export function CouponForm({
         className="adminSettingsField"
         control={control}
         name="name"
-        label="쿠폰명"
+        label="내부 관리명"
         required
         error={errors.name?.message}
+      />
+
+      <ControlledTextField
+        className="adminSettingsField"
+        control={control}
+        name="displayName"
+        label="고객 표시명"
+        required
+        error={errors.displayName?.message}
       />
 
       <RadioSelectBoxRoot

--- a/apps/admin/src/features/coupons/types/admin-coupon.ts
+++ b/apps/admin/src/features/coupons/types/admin-coupon.ts
@@ -3,6 +3,7 @@ export type CouponDiscountType = "percentage" | "fixed";
 export interface AdminCoupon {
   id: string;
   name: string;
+  displayName: string;
   discountType: CouponDiscountType;
   discountValue: number;
   maxDiscountAmount: number | null;
@@ -16,6 +17,7 @@ export interface AdminCoupon {
 
 export interface AdminCouponFormValues {
   name: string;
+  displayName: string;
   discountType: CouponDiscountType;
   discountValue: number | null;
   maxDiscountAmount: number | null;
@@ -33,6 +35,7 @@ export interface AdminCouponListResult {
 export function createDefaultCouponFormValues(): AdminCouponFormValues {
   return {
     name: "",
+    displayName: "",
     discountType: "percentage",
     discountValue: null,
     maxDiscountAmount: null,

--- a/apps/admin/src/pages/coupons/list.tsx
+++ b/apps/admin/src/pages/coupons/list.tsx
@@ -6,6 +6,7 @@ import { Callout } from "seed-design/ui/callout";
 import { AdminPageHeader } from "@/components/AdminPageHeader";
 import { AdminPanelHeader } from "@/components/AdminPanelHeader";
 import { AdminDataTable } from "@/components/AdminDataTable";
+import { formatCouponName } from "@yeongseon/shared/utils/format-coupon-name";
 import {
   COUPON_PAGE_SIZE,
   CouponStatusBadge,
@@ -22,7 +23,16 @@ function formatDiscount(coupon: AdminCoupon): string {
 }
 
 const COUPON_COLUMNS: ColumnDef<AdminCoupon>[] = [
-  { accessorKey: "name", header: "쿠폰명" },
+  { accessorKey: "name", header: "내부 관리명" },
+  {
+    accessorKey: "displayName",
+    header: "고객 표시명",
+    cell: ({ row }) => (
+      <Text as="span" textStyle="t4Regular">
+        {formatCouponName(row.original)}
+      </Text>
+    ),
+  },
   {
     accessorKey: "discountType",
     header: "할인유형",
@@ -115,7 +125,7 @@ export default function CouponList() {
               search: location.search,
             })
           }
-          getRowActionLabel={(row) => `${row.name} 쿠폰 수정`}
+          getRowActionLabel={(row) => `${row.name} 내부 관리 쿠폰 수정`}
           isLoading={query.isFetching}
         />
 

--- a/apps/store/src/entities/claim/api/claims-mapper.ts
+++ b/apps/store/src/entities/claim/api/claims-mapper.ts
@@ -327,6 +327,10 @@ const parseClaimItemField = (
       coupon: {
         id: v.appliedCoupon.coupon.id,
         name: v.appliedCoupon.coupon.name,
+        displayName:
+          typeof v.appliedCoupon.coupon.displayName === "string"
+            ? v.appliedCoupon.coupon.displayName
+            : null,
         discountType: v.appliedCoupon.coupon.discountType,
         discountValue: v.appliedCoupon.coupon.discountValue,
         expiryDate: v.appliedCoupon.coupon.expiryDate,

--- a/apps/store/src/entities/coupon/api/coupons-api.ts
+++ b/apps/store/src/entities/coupon/api/coupons-api.ts
@@ -7,7 +7,7 @@ import {
 } from "@/entities/coupon/api/coupons-mapper";
 
 const COUPON_COLUMNS =
-  "id, name, discount_type, discount_value, max_discount_amount, description, expiry_date, additional_info";
+  "id, name, display_name, discount_type, discount_value, max_discount_amount, description, expiry_date, additional_info";
 
 const USER_COUPON_COLUMNS = `id, user_id, coupon_id, status, issued_at, expires_at, used_at, coupon:coupons(${COUPON_COLUMNS})`;
 

--- a/apps/store/src/entities/coupon/api/coupons-mapper.test.ts
+++ b/apps/store/src/entities/coupon/api/coupons-mapper.test.ts
@@ -18,6 +18,7 @@ const createUserCouponRecordRaw = (
   coupon: {
     id: "coupon-1",
     name: "10% 할인",
+    display_name: "봄맞이 10% 할인",
     discount_type: "percentage",
     discount_value: 10,
     max_discount_amount: 3000,
@@ -42,6 +43,7 @@ describe("parseUserCouponRecords", () => {
         coupon: {
           id: "coupon-1",
           name: "10% 할인",
+          display_name: "봄맞이 10% 할인",
           discount_type: "percentage",
           discount_value: 10,
           max_discount_amount: 3000,

--- a/apps/store/src/entities/coupon/api/coupons-mapper.test.ts
+++ b/apps/store/src/entities/coupon/api/coupons-mapper.test.ts
@@ -65,6 +65,23 @@ describe("parseUserCouponRecords", () => {
     );
   });
 
+  it("coupon.display_name은 trim하고 빈 값이면 null로 정규화한다", () => {
+    const coupon = {
+      ...(createUserCouponRecordRaw().coupon as Record<string, unknown>),
+      display_name: "   ",
+    };
+
+    expect(
+      parseUserCouponRecords([createUserCouponRecordRaw({ coupon })])[0],
+    ).toEqual(
+      expect.objectContaining({
+        coupon: expect.objectContaining({
+          display_name: null,
+        }),
+      }),
+    );
+  });
+
   it("reserved 상태 쿠폰도 허용한다", () => {
     expect(
       parseUserCouponRecords([
@@ -140,6 +157,7 @@ describe("coupon record -> view", () => {
     expect(mapRecordToCoupon(record)).toEqual(
       expect.objectContaining({
         id: "coupon-1",
+        displayName: "봄맞이 10% 할인",
         discountType: "percentage",
       }),
     );
@@ -151,7 +169,10 @@ describe("coupon record -> view", () => {
     expect(mapRecordToUserCoupon(record)).toEqual(
       expect.objectContaining({
         id: "uc-1",
-        coupon: expect.objectContaining({ name: "10% 할인" }),
+        coupon: expect.objectContaining({
+          name: "10% 할인",
+          displayName: "봄맞이 10% 할인",
+        }),
       }),
     );
     expect(() => mapRecordToUserCoupon({ ...record, coupon: null })).toThrow(

--- a/apps/store/src/entities/coupon/api/coupons-mapper.ts
+++ b/apps/store/src/entities/coupon/api/coupons-mapper.ts
@@ -48,10 +48,12 @@ const parseCouponRecord = (v: unknown, i: number): CouponRecord | null => {
       `쿠폰 조회 행(${i})의 coupon이 올바르지 않습니다: discount_type 값(${v.discount_type})이 허용된 유형("percentage" | "fixed")이 아닙니다.`,
     );
   }
+  const displayName =
+    typeof v.display_name === "string" ? v.display_name.trim() : "";
   return {
     id: v.id,
     name: v.name,
-    display_name: typeof v.display_name === "string" ? v.display_name : null,
+    display_name: displayName === "" ? null : displayName,
     discount_type: v.discount_type,
     discount_value: v.discount_value,
     max_discount_amount:

--- a/apps/store/src/entities/coupon/api/coupons-mapper.ts
+++ b/apps/store/src/entities/coupon/api/coupons-mapper.ts
@@ -51,6 +51,7 @@ const parseCouponRecord = (v: unknown, i: number): CouponRecord | null => {
   return {
     id: v.id,
     name: v.name,
+    display_name: typeof v.display_name === "string" ? v.display_name : null,
     discount_type: v.discount_type,
     discount_value: v.discount_value,
     max_discount_amount:
@@ -110,6 +111,7 @@ export const parseUserCouponRecords = (data: unknown): UserCouponRecord[] => {
 export const mapRecordToCoupon = (record: CouponRecord): Coupon => ({
   id: record.id,
   name: record.name,
+  displayName: record.display_name,
   discountType: record.discount_type,
   discountValue: Number(record.discount_value),
   maxDiscountAmount:

--- a/apps/store/src/entities/coupon/model/coupon-record.ts
+++ b/apps/store/src/entities/coupon/model/coupon-record.ts
@@ -3,6 +3,7 @@ import type { UserCouponStatus } from "@yeongseon/shared/types/view/coupon";
 export interface CouponRecord {
   id: string;
   name: string;
+  display_name: string | null;
   discount_type: "percentage" | "fixed";
   discount_value: number;
   max_discount_amount: number | null;

--- a/apps/store/src/entities/order/api/order-mapper.ts
+++ b/apps/store/src/entities/order/api/order-mapper.ts
@@ -410,6 +410,8 @@ const parseAppliedCouponField = (
     coupon: {
       id: v.coupon.id,
       name: v.coupon.name,
+      displayName:
+        typeof v.coupon.displayName === "string" ? v.coupon.displayName : null,
       discountType: v.coupon.discountType,
       discountValue: v.coupon.discountValue,
       expiryDate: v.coupon.expiryDate,

--- a/packages/shared/src/types/dto/coupon.ts
+++ b/packages/shared/src/types/dto/coupon.ts
@@ -1,6 +1,7 @@
 export interface CouponDTO {
   id: string;
   name: string;
+  displayName?: string | null;
   discountType: "percentage" | "fixed";
   discountValue: number;
   maxDiscountAmount?: number | null;

--- a/packages/shared/src/types/view/coupon.ts
+++ b/packages/shared/src/types/view/coupon.ts
@@ -1,6 +1,7 @@
 export interface Coupon {
   id: string;
   name: string;
+  displayName?: string | null;
   discountType: "percentage" | "fixed";
   discountValue: number;
   maxDiscountAmount?: number | null;

--- a/packages/shared/src/utils/format-coupon-name.test.ts
+++ b/packages/shared/src/utils/format-coupon-name.test.ts
@@ -21,4 +21,26 @@ describe("formatCouponName", () => {
       "신규 가입 쿠폰",
     );
   });
+
+  it("고객 표시명이 있으면 내부 관리명 대신 고객 표시명을 사용한다", () => {
+    expect(
+      formatCouponName(
+        createCoupon({
+          name: "WELCOME_10",
+          displayName: "신규 가입 10% 할인 쿠폰",
+        }),
+      ),
+    ).toBe("신규 가입 10% 할인 쿠폰");
+  });
+
+  it("고객 표시명이 없고 내부 관리명이 내부용이면 설명을 고객 표시명 fallback으로 사용한다", () => {
+    expect(
+      formatCouponName(
+        createCoupon({
+          name: "WELCOME_10",
+          description: "신규 가입 10% 할인 쿠폰",
+        }),
+      ),
+    ).toBe("신규 가입 10% 할인 쿠폰");
+  });
 });

--- a/packages/shared/src/utils/format-coupon-name.ts
+++ b/packages/shared/src/utils/format-coupon-name.ts
@@ -9,5 +9,15 @@ const SYSTEM_COUPON_LABELS: Record<string, string> = {
     "원단+봉제 샘플 할인 쿠폰 (선염)",
 };
 
-export const formatCouponName = (coupon: Pick<Coupon, "name">): string =>
-  SYSTEM_COUPON_LABELS[coupon.name] ?? coupon.name;
+export const formatCouponName = (
+  coupon: Pick<Coupon, "name" | "displayName" | "description">,
+): string => {
+  const displayName = coupon.displayName?.trim();
+  const description = coupon.description?.trim();
+  return (
+    displayName ||
+    SYSTEM_COUPON_LABELS[coupon.name] ||
+    description ||
+    coupon.name
+  );
+};

--- a/supabase/migrations/20260607230449_add_coupon_display_name.sql
+++ b/supabase/migrations/20260607230449_add_coupon_display_name.sql
@@ -1,0 +1,282 @@
+ALTER TABLE public.coupons
+ADD COLUMN IF NOT EXISTS display_name text;
+
+UPDATE public.coupons
+SET display_name = coalesce(
+  nullif(display_name, ''),
+  CASE name
+    WHEN 'SAMPLE_DISCOUNT_SEWING' THEN '봉제 샘플 할인 쿠폰'
+    WHEN 'SAMPLE_DISCOUNT_FABRIC_PRINTING' THEN '원단 샘플 할인 쿠폰 (날염)'
+    WHEN 'SAMPLE_DISCOUNT_FABRIC_YARN_DYED' THEN '원단 샘플 할인 쿠폰 (선염)'
+    WHEN 'SAMPLE_DISCOUNT_FABRIC_AND_SEWING_PRINTING' THEN '원단+봉제 샘플 할인 쿠폰 (날염)'
+    WHEN 'SAMPLE_DISCOUNT_FABRIC_AND_SEWING_YARN_DYED' THEN '원단+봉제 샘플 할인 쿠폰 (선염)'
+    ELSE null
+  END,
+  nullif(description, ''),
+  name
+);
+
+CREATE OR REPLACE VIEW public.order_item_view
+WITH (security_invoker = true)
+AS
+SELECT
+  oi.order_id,
+  oi.created_at,
+  oi.item_id AS id,
+  oi.item_type AS type,
+  CASE
+    WHEN oi.item_type = 'product' THEN to_jsonb(p)
+    ELSE null
+  END AS product,
+  CASE
+    WHEN oi.item_type = 'product' AND oi.selected_option_id IS NOT NULL THEN (
+      SELECT option
+      FROM jsonb_array_elements(coalesce(to_jsonb(p)->'options', '[]'::jsonb)) option
+      WHERE option->>'id' = oi.selected_option_id
+      LIMIT 1
+    )
+    ELSE null
+  END AS "selectedOption",
+  oi.quantity,
+  CASE
+    WHEN oi.item_type IN ('reform', 'custom', 'sample') THEN oi.item_data
+    ELSE null
+  END AS "reformData",
+  uc.user_coupon AS "appliedCoupon",
+  CASE
+    WHEN oi.item_type = 'sample' THEN oi.item_data
+    ELSE null
+  END AS "sampleData"
+FROM public.order_items oi
+JOIN public.orders o
+  ON o.id = oi.order_id AND o.user_id = auth.uid()
+LEFT JOIN LATERAL (
+  SELECT
+    plv.id, plv.code, plv.name, plv.price, plv.image,
+    plv."detailImages", plv.category, plv.color, plv.pattern,
+    plv.material, plv.info, plv.created_at, plv.updated_at,
+    plv.options, plv.likes, plv."isLiked"
+  FROM public.product_list_view plv
+  WHERE oi.item_type = 'product'
+    AND oi.product_id IS NOT NULL
+    AND plv.id = oi.product_id
+  LIMIT 1
+) p ON true
+LEFT JOIN LATERAL (
+  SELECT
+    uc1.id,
+    jsonb_build_object(
+      'id', uc1.id,
+      'userId', uc1.user_id,
+      'couponId', uc1.coupon_id,
+      'status', uc1.status,
+      'issuedAt', uc1.issued_at,
+      'expiresAt', uc1.expires_at,
+      'usedAt', uc1.used_at,
+      'coupon', jsonb_build_object(
+        'id', c.id,
+        'name', c.name,
+        'displayName', c.display_name,
+        'discountType', c.discount_type,
+        'discountValue', c.discount_value,
+        'maxDiscountAmount', c.max_discount_amount,
+        'description', c.description,
+        'expiryDate', c.expiry_date,
+        'additionalInfo', c.additional_info
+      )
+    ) AS user_coupon
+  FROM public.user_coupons uc1
+  JOIN public.coupons c ON c.id = uc1.coupon_id
+  WHERE uc1.id = oi.applied_user_coupon_id
+  LIMIT 1
+) uc ON true
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.claims cl
+  WHERE cl.order_item_id = oi.id
+);
+
+CREATE OR REPLACE VIEW public.claim_list_view
+WITH (security_invoker = true)
+AS
+SELECT
+  cl.id,
+  cl.claim_number AS "claimNumber",
+  to_char(cl.created_at, 'YYYY-MM-DD') AS date,
+  cl.status,
+  cl.type,
+  cl.reason,
+  cl.description,
+  cl.quantity AS "claimQuantity",
+  o.id AS "orderId",
+  o.order_number AS "orderNumber",
+  to_char(o.created_at, 'YYYY-MM-DD') AS "orderDate",
+  jsonb_build_object(
+    'id', oi.item_id,
+    'type', oi.item_type,
+    'product', CASE
+      WHEN oi.item_type = 'product' THEN to_jsonb(p)
+      ELSE null
+    END,
+    'selectedOption', CASE
+      WHEN oi.item_type = 'product' AND oi.selected_option_id IS NOT NULL THEN (
+        SELECT option
+        FROM jsonb_array_elements(coalesce(to_jsonb(p)->'options', '[]'::jsonb)) option
+        WHERE option->>'id' = oi.selected_option_id
+        LIMIT 1
+      )
+      ELSE null
+    END,
+    'quantity', oi.quantity,
+    'reformData', CASE
+      WHEN oi.item_type IN ('reform', 'custom', 'sample') THEN oi.item_data
+      ELSE null
+    END,
+    'sampleData', CASE
+      WHEN oi.item_type = 'sample' THEN oi.item_data
+      ELSE null
+    END,
+    'appliedCoupon', uc.user_coupon
+  ) AS item,
+  cl.refund_data
+FROM public.claims cl
+JOIN public.orders o
+  ON o.id = cl.order_id AND o.user_id = auth.uid()
+JOIN public.order_items oi
+  ON oi.id = cl.order_item_id
+LEFT JOIN LATERAL (
+  SELECT
+    plv.id, plv.code, plv.name, plv.price, plv.image,
+    plv."detailImages", plv.category, plv.color, plv.pattern,
+    plv.material, plv.info, plv.created_at, plv.updated_at,
+    plv.options, plv.likes, plv."isLiked"
+  FROM public.product_list_view plv
+  WHERE oi.item_type = 'product'
+    AND oi.product_id IS NOT NULL
+    AND plv.id = oi.product_id
+  LIMIT 1
+) p ON true
+LEFT JOIN LATERAL (
+  SELECT
+    uc1.id,
+    jsonb_build_object(
+      'id', uc1.id,
+      'userId', uc1.user_id,
+      'couponId', uc1.coupon_id,
+      'status', uc1.status,
+      'issuedAt', uc1.issued_at,
+      'expiresAt', uc1.expires_at,
+      'usedAt', uc1.used_at,
+      'coupon', jsonb_build_object(
+        'id', cp.id,
+        'name', cp.name,
+        'displayName', cp.display_name,
+        'discountType', cp.discount_type,
+        'discountValue', cp.discount_value,
+        'maxDiscountAmount', cp.max_discount_amount,
+        'description', cp.description,
+        'expiryDate', cp.expiry_date,
+        'additionalInfo', cp.additional_info
+      )
+    ) AS user_coupon
+  FROM public.user_coupons uc1
+  JOIN public.coupons cp ON cp.id = uc1.coupon_id
+  WHERE uc1.id = oi.applied_user_coupon_id
+  LIMIT 1
+) uc ON true
+WHERE cl.user_id = auth.uid();
+
+CREATE OR REPLACE FUNCTION public.get_cart_items(p_user_id uuid, p_active_only boolean DEFAULT true)
+RETURNS SETOF jsonb
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  with cart as (
+    select *
+    from cart_items
+    where user_id = p_user_id
+      and user_id = auth.uid()
+    order by created_at asc
+  ),
+  product_ids as (
+    select array_agg(distinct product_id)::integer[] as ids
+    from cart
+    where product_id is not null
+  ),
+  products as (
+    select *
+    from get_products_by_ids(
+      coalesce((select ids from product_ids), '{}'::integer[])
+    )
+  ),
+  coupon_ids as (
+    select array_agg(distinct applied_user_coupon_id)::uuid[] as ids
+    from cart
+    where applied_user_coupon_id is not null
+  ),
+  coupons as (
+    select
+      uc.id,
+      jsonb_build_object(
+        'id', uc.id,
+        'userId', uc.user_id,
+        'couponId', uc.coupon_id,
+        'status', uc.status,
+        'issuedAt', uc.issued_at,
+        'expiresAt', uc.expires_at,
+        'usedAt', uc.used_at,
+        'coupon', jsonb_build_object(
+          'id', c.id,
+          'name', c.name,
+          'displayName', c.display_name,
+          'discountType', c.discount_type,
+          'discountValue', c.discount_value,
+          'maxDiscountAmount', c.max_discount_amount,
+          'description', c.description,
+          'expiryDate', c.expiry_date,
+          'additionalInfo', c.additional_info
+        )
+      ) as user_coupon
+    from user_coupons uc
+    join coupons c on c.id = uc.coupon_id
+    where uc.user_id = p_user_id
+      and uc.user_id = auth.uid()
+      and uc.id = any(coalesce((select ids from coupon_ids), '{}'::uuid[]))
+      and (
+        not p_active_only
+        or (
+          uc.status = 'active'
+          and (uc.expires_at is null or uc.expires_at > now())
+          and c.is_active = true
+          and c.expiry_date >= current_date
+        )
+      )
+  )
+  select jsonb_build_object(
+    'id', cart.item_id,
+    'type', cart.item_type,
+    'product', case
+      when cart.item_type = 'product' then to_jsonb(p)
+      else null
+    end,
+    'selectedOption', case
+      when cart.item_type = 'product' and cart.selected_option_id is not null then (
+        select option
+        from jsonb_array_elements(
+          coalesce(to_jsonb(p)->'options', '[]'::jsonb)
+        ) option
+        where option->>'id' = cart.selected_option_id
+        limit 1
+      )
+      else null
+    end,
+    'quantity', cart.quantity,
+    'reformData', cart.reform_data,
+    'appliedCoupon', coupons.user_coupon,
+    'appliedCouponId', cart.applied_user_coupon_id
+  )
+  from cart
+  left join products p on p.id = cart.product_id
+  left join coupons on coupons.id = cart.applied_user_coupon_id
+  order by cart.created_at asc;
+$$;

--- a/supabase/migrations/20260607234500_remove_legacy_sample_discount_coupon.sql
+++ b/supabase/migrations/20260607234500_remove_legacy_sample_discount_coupon.sql
@@ -1,0 +1,10 @@
+-- 20260319000000_sample_order_type.sql에서 생성되고
+-- 20260320000000_sample_pricing_by_type.sql에서 비활성화된
+-- 레거시 통합 샘플 할인 쿠폰(SAMPLE_DISCOUNT)을 제거한다.
+-- 유형별 쿠폰(SAMPLE_DISCOUNT_*) 5종으로 대체되어 더 이상 사용되지 않는다.
+-- 발급 이력(user_coupons)이 있으면 FK 위반을 피하기 위해 삭제하지 않고 남긴다.
+DELETE FROM public.coupons c
+WHERE c.name = 'SAMPLE_DISCOUNT'
+  AND NOT EXISTS (
+    SELECT 1 FROM public.user_coupons uc WHERE uc.coupon_id = c.id
+  );

--- a/supabase/migrations/20260607234500_remove_legacy_sample_discount_coupon.sql
+++ b/supabase/migrations/20260607234500_remove_legacy_sample_discount_coupon.sql
@@ -1,8 +1,3 @@
--- 20260319000000_sample_order_type.sql에서 생성되고
--- 20260320000000_sample_pricing_by_type.sql에서 비활성화된
--- 레거시 통합 샘플 할인 쿠폰(SAMPLE_DISCOUNT)을 제거한다.
--- 유형별 쿠폰(SAMPLE_DISCOUNT_*) 5종으로 대체되어 더 이상 사용되지 않는다.
--- 발급 이력(user_coupons)이 있으면 FK 위반을 피하기 위해 삭제하지 않고 남긴다.
 DELETE FROM public.coupons c
 WHERE c.name = 'SAMPLE_DISCOUNT'
   AND NOT EXISTS (

--- a/supabase/schemas/30_coupons.sql
+++ b/supabase/schemas/30_coupons.sql
@@ -24,6 +24,8 @@ CREATE TABLE IF NOT EXISTS public.coupons (
     CHECK (discount_value > 0)
 );
 
+COMMENT ON TABLE public.coupons IS 'Coupons include legacy sample discount cleanup: SAMPLE_DISCOUNT was created by 20260319000000_sample_order_type.sql, disabled by 20260320000000_sample_pricing_by_type.sql, and superseded by five SAMPLE_DISCOUNT_* type-specific coupons. Migration 20260607234500_remove_legacy_sample_discount_coupon.sql deletes it only when no user_coupons issuance history references it.';
+
 -- Indexes
 CREATE INDEX coupons_active_idx ON public.coupons USING btree (is_active);
 CREATE INDEX coupons_expiry_idx ON public.coupons USING btree (expiry_date);

--- a/supabase/schemas/30_coupons.sql
+++ b/supabase/schemas/30_coupons.sql
@@ -5,6 +5,7 @@
 CREATE TABLE IF NOT EXISTS public.coupons (
   id                  uuid          NOT NULL DEFAULT extensions.uuid_generate_v4(),
   name                text          NOT NULL,
+  display_name        text,
   discount_type       text          NOT NULL,
   discount_value      numeric(10,2) NOT NULL,
   max_discount_amount numeric(10,2),

--- a/supabase/schemas/90_views.sql
+++ b/supabase/schemas/90_views.sql
@@ -163,6 +163,7 @@ LEFT JOIN LATERAL (
       'coupon', jsonb_build_object(
         'id', c.id,
         'name', c.name,
+        'displayName', c.display_name,
         'discountType', c.discount_type,
         'discountValue', c.discount_value,
         'maxDiscountAmount', c.max_discount_amount,
@@ -256,6 +257,7 @@ LEFT JOIN LATERAL (
       'coupon', jsonb_build_object(
         'id', cp.id,
         'name', cp.name,
+        'displayName', cp.display_name,
         'discountType', cp.discount_type,
         'discountValue', cp.discount_value,
         'maxDiscountAmount', cp.max_discount_amount,

--- a/supabase/schemas/92_functions_cart.sql
+++ b/supabase/schemas/92_functions_cart.sql
@@ -161,6 +161,7 @@ AS $$
         'coupon', jsonb_build_object(
           'id', c.id,
           'name', c.name,
+          'displayName', c.display_name,
           'discountType', c.discount_type,
           'discountValue', c.discount_value,
           'maxDiscountAmount', c.max_discount_amount,
@@ -212,4 +213,3 @@ AS $$
   left join coupons on coupons.id = cart.applied_user_coupon_id
   order by cart.created_at asc;
 $$;
-

--- a/supabase/schemas/98_functions_payment.sql
+++ b/supabase/schemas/98_functions_payment.sql
@@ -204,10 +204,26 @@ begin
       end if;
 
       -- coupons row 동기화 (user_coupons FK용)
-      insert into public.coupons (name, discount_type, discount_value, max_discount_amount, expiry_date, is_active)
-      values (v_coupon_name, 'fixed', v_discount_amount, v_discount_amount, '2099-12-31', true)
+      insert into public.coupons (name, display_name, discount_type, discount_value, max_discount_amount, expiry_date, is_active)
+      values (
+        v_coupon_name,
+        case v_coupon_name
+          when 'SAMPLE_DISCOUNT_SEWING' then '봉제 샘플 할인 쿠폰'
+          when 'SAMPLE_DISCOUNT_FABRIC_PRINTING' then '원단 샘플 할인 쿠폰 (날염)'
+          when 'SAMPLE_DISCOUNT_FABRIC_YARN_DYED' then '원단 샘플 할인 쿠폰 (선염)'
+          when 'SAMPLE_DISCOUNT_FABRIC_AND_SEWING_PRINTING' then '원단+봉제 샘플 할인 쿠폰 (날염)'
+          when 'SAMPLE_DISCOUNT_FABRIC_AND_SEWING_YARN_DYED' then '원단+봉제 샘플 할인 쿠폰 (선염)'
+          else v_coupon_name
+        end,
+        'fixed',
+        v_discount_amount,
+        v_discount_amount,
+        '2099-12-31',
+        true
+      )
       on conflict (name)
       do update set discount_value = excluded.discount_value,
+                   display_name = excluded.display_name,
                    max_discount_amount = excluded.max_discount_amount,
                    discount_type = excluded.discount_type,
                    expiry_date = excluded.expiry_date,

--- a/supabase/seeds/20_dev_fixture.sql
+++ b/supabase/seeds/20_dev_fixture.sql
@@ -35,6 +35,7 @@ SET recipient_name = EXCLUDED.recipient_name,
 INSERT INTO public.coupons (
   id,
   name,
+  display_name,
   discount_type,
   discount_value,
   max_discount_amount,
@@ -46,6 +47,7 @@ INSERT INTO public.coupons (
 VALUES (
   '40000000-0000-4000-8000-000000000001',
   '로컬 개발 주문 쿠폰',
+  '로컬 개발 주문 쿠폰',
   'fixed',
   1000,
   1000,
@@ -56,6 +58,7 @@ VALUES (
 )
 ON CONFLICT (name) DO UPDATE
 SET discount_type = EXCLUDED.discount_type,
+    display_name = EXCLUDED.display_name,
     discount_value = EXCLUDED.discount_value,
     max_discount_amount = EXCLUDED.max_discount_amount,
     description = EXCLUDED.description,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 쿠폰에 고객용 표시명(display name) 추가 — 관리자가 내부명과 별도로 고객에게 보일 이름을 설정 가능.
  * 관리 UI에서 내부관리명 레이블 변경 및 고객용 표시명 입력 필드 추가.
  * 주문·장바구니·클레임·목록 등에서 쿠폰의 표시명을 우선 보여주도록 개선.

* **테스트**
  * 표시명 우선순위 및 공백 정규화 동작을 확인하는 테스트 추가.

* **데이터베이스**
  * 쿠폰 표시명 컬럼 및 관련 뷰/함수/시드/마이그레이션 반영.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->